### PR TITLE
Fix missable USB interrupts

### DIFF
--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -340,6 +340,8 @@ void dcd_int_enable (uint8_t rhport)
 #else
   #error Unknown arch in USB driver
 #endif
+
+  dcd_int_handler(rhport);
 }
 
 // Disable device interrupt
@@ -392,6 +394,9 @@ void dcd_int_disable(uint8_t rhport)
 #else
   #error Unknown arch in USB driver
 #endif
+
+  __DSB();
+  __ISB();
 
   // CMSIS has a membar after disabling interrupts
 }
@@ -1162,4 +1167,3 @@ static bool dcd_read_packet_memory_ff(tu_fifo_t * ff, uint16_t src, uint16_t wNB
 #endif
 
 #endif
-


### PR DESCRIPTION
The USB interrupts are disabled and enabled at various stages within TinyUSB. For example when the FiFo buffer is read in the [queue handling](https://github.com/WootingKb/tinyusb/blob/d23c9b7cd681b972d310e401b418f4368507e06f/src/device/usbd.c#L480). Due to this there can be a race condition that an interrupt can be missed which can cause the whole USB communication to stop working for a few seconds.

- Calling the interrupt handling routine every time the interrupts are enabled again to prevent a race condition
- Adding a synchronization barrier when the interrupts get disabled (following ARM errata 838869)