### PR TITLE
Fix missable USB interrupts

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1162,6 +1162,9 @@ void usbd_int_set(bool enabled)
   if (enabled)
   {
     dcd_int_enable(_usbd_rhport);
+
+    // Trigger USB interrupt handling in the case one was missed when temporary disabled
+    dcd_int_handler(_usbd_rhport);
   }else
   {
     dcd_int_disable(_usbd_rhport);

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -340,6 +340,8 @@ void dcd_int_enable (uint8_t rhport)
 #else
   #error Unknown arch in USB driver
 #endif
+
+  dcd_int_handler(rhport);
 }
 
 // Disable device interrupt
@@ -392,6 +394,9 @@ void dcd_int_disable(uint8_t rhport)
 #else
   #error Unknown arch in USB driver
 #endif
+
+  __DSB();
+  __ISB();
 
   // CMSIS has a membar after disabling interrupts
 }
@@ -1162,4 +1167,3 @@ static bool dcd_read_packet_memory_ff(tu_fifo_t * ff, uint16_t src, uint16_t wNB
 #endif
 
 #endif
-

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -340,8 +340,6 @@ void dcd_int_enable (uint8_t rhport)
 #else
   #error Unknown arch in USB driver
 #endif
-
-  dcd_int_handler(rhport);
 }
 
 // Disable device interrupt
@@ -395,6 +393,7 @@ void dcd_int_disable(uint8_t rhport)
   #error Unknown arch in USB driver
 #endif
 
+  // Member here forces write to RAM before allowing ISR to execute
   __DSB();
   __ISB();
 


### PR DESCRIPTION
The USB interrupts are disabled and enabled at various stages within TinyUSB. For example when the FiFo buffer is read in the [queue handling](https://github.com/WootingKb/tinyusb/blob/d23c9b7cd681b972d310e401b418f4368507e06f/src/device/usbd.c#L480). Due to this there can be a race condition that an interrupt can be missed which can cause the whole USB communication to stop working for a few seconds.

- Calling the interrupt handling routine every time the interrupts are enabled again to prevent a race condition
- Adding a synchronization barrier when the interrupts get disabled (following ARM errata 838869)