### PR TITLE
Generic driver selection for GD32 FSDEV

### DIFF
--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -243,6 +243,7 @@
   #define TUP_DCD_ENDPOINT_MAX    4
 
 #elif TU_CHECK_MCU(OPT_MCU_GD32F303)
+  #define TUP_USBIP_FSDEV
   #define TUP_DCD_ENDPOINT_MAX  8
 
 //------------- Broadcom -------------//

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -112,7 +112,7 @@
 #if CFG_TUD_ENABLED && \
       ( TU_CHECK_MCU(OPT_MCU_STM32F0, OPT_MCU_STM32F3, OPT_MCU_STM32L0, OPT_MCU_STM32L1, OPT_MCU_STM32G4, OPT_MCU_STM32WB) || \
         (TU_CHECK_MCU(OPT_MCU_STM32F1) && defined(STM32F1_FSDEV)) || \
-        (TU_CHECK_MCU(OPT_MCU_GD32F303) && defined(GD32F3_FSDEV)) \
+        defined(TUP_USBIP_FSDEV) \
       )
 
 // In order to reduce the dependance on HAL, we undefine this.


### PR DESCRIPTION
- Assigning the driver selection via the general MCU config
- Removing the individual driver selection from the driver source file