### PR TITLE
Enable fallback SOF on DWC2

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -1313,6 +1313,10 @@ void dcd_int_handler(uint8_t rhport)
   if(int_status & GINTSTS_WKUINT)
   {
     dwc2->gintsts = GINTSTS_WKUINT;
+
+    // enable SOF to detect bus resume
+    dwc2->gintsts = GINTSTS_SOF;
+    dwc2->gintmsk |= GINTMSK_SOFM;
   }
 
   // TODO check GINTSTS_DISCINT for disconnect detection


### PR DESCRIPTION
- Enabled the start of frame on the DWC2 driver when a device resume is detected
- Prevents that the device might remain in the sleep mode if the host doesn't allow the device to resume operation
